### PR TITLE
Add timeout for in-flight print jobs

### DIFF
--- a/ZPLWeb/utils.py
+++ b/ZPLWeb/utils.py
@@ -1,7 +1,10 @@
-import sys
-import os
-
 import hashlib
+import os
+import sys
+import time
+from collections.abc import MutableMapping
+from typing import TypeVar
+
 
 def _make_fingerprint(invoice, pcs, zpl) -> str:
     h = hashlib.sha256()
@@ -9,6 +12,28 @@ def _make_fingerprint(invoice, pcs, zpl) -> str:
     h.update(str(pcs or "").encode("utf-8"))
     h.update((zpl or "").encode("utf-8"))
     return h.hexdigest()
+
+
+K = TypeVar("K")
+
+
+def expire_stale_jobs(
+    store: MutableMapping[K, float], ttl: float, now: float | None = None
+) -> None:
+    """Remove entries older than ``ttl`` seconds from ``store``.
+
+    Args:
+        store: Mapping of identifiers to their insertion timestamps.
+        ttl: Maximum age in seconds before an entry is discarded.
+        now: Current timestamp. Defaults to :func:`time.time` when ``None``.
+
+    """
+    if now is None:
+        now = time.time()
+    for key, ts in list(store.items()):
+        if now - ts > ttl:
+            del store[key]
+
 
 def resource_path(relative_path: str) -> str:
     """Return absolute path to a bundled resource.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,3 +18,10 @@ def test_resource_path_dev(monkeypatch):
     monkeypatch.setattr(mod, "sys", types.SimpleNamespace(frozen=False))
     expected = os.path.join(os.path.abspath(os.path.dirname(mod.__file__)), "bar")
     assert mod.resource_path("bar") == expected
+
+
+def test_expire_stale_jobs():
+    store = {1: 0.0, 2: 10.0}
+    utils.expire_stale_jobs(store, ttl=5, now=12.0)
+    assert 1 not in store
+    assert 2 in store


### PR DESCRIPTION
## Summary
- expire stale tracking entries with new `expire_stale_jobs` helper
- retry stuck print jobs after 30s timeout
- test and document cleanup logic

## Testing
- `python -m isort ZPLWeb/main.py ZPLWeb/utils.py tests/test_utils.py`
- `python -m black ZPLWeb/main.py ZPLWeb/utils.py tests/test_utils.py`
- `python -m flake8 ZPLWeb/main.py ZPLWeb/utils.py tests/test_utils.py`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689598ae81e483228bd8137b69428faa