### PR TITLE
fix(windows): prevent multiple instances

### DIFF
--- a/ZPLWeb/__init__.py
+++ b/ZPLWeb/__init__.py
@@ -1,1 +1,5 @@
+"""Utility exports for the ZPLWeb package."""
+
 from .utils import resource_path
+
+__all__ = ["resource_path"]

--- a/ZPLWeb/main.py
+++ b/ZPLWeb/main.py
@@ -31,7 +31,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from ZPLWeb.utils import resource_path
+from ZPLWeb.utils import ensure_single_instance, resource_path
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Platform‑specific printer import
@@ -639,6 +639,8 @@ class MainWindow(QMainWindow):
 
 
 def main():
+    if not ensure_single_instance("Coleman Print Agent"):
+        return
     app = QApplication(sys.argv)
     app.setQuitOnLastWindowClosed(False)
 

--- a/ZPLWeb/utils.py
+++ b/ZPLWeb/utils.py
@@ -1,7 +1,7 @@
-import sys
-import os
-
 import hashlib
+import os
+import sys
+
 
 def _make_fingerprint(invoice, pcs, zpl) -> str:
     h = hashlib.sha256()
@@ -9,6 +9,7 @@ def _make_fingerprint(invoice, pcs, zpl) -> str:
     h.update(str(pcs or "").encode("utf-8"))
     h.update((zpl or "").encode("utf-8"))
     return h.hexdigest()
+
 
 def resource_path(relative_path: str) -> str:
     """Return absolute path to a bundled resource.
@@ -27,3 +28,38 @@ def resource_path(relative_path: str) -> str:
         base_path = os.path.abspath(os.path.dirname(__file__))
 
     return os.path.join(base_path, relative_path)
+
+
+def ensure_single_instance(window_title: str) -> bool:
+    """Prevent multiple Windows instances and focus existing window.
+
+    On Windows, a named mutex guards against launching more than one
+    instance of the application. If a prior instance is detected, its
+    window is restored and focused.
+
+    Args:
+        window_title: Title of the main window used for lookup.
+
+    Returns:
+        ``True`` if this is the primary instance and startup should
+        continue. ``False`` if another instance is activated instead.
+    """
+    if not sys.platform.startswith("win"):
+        return True
+    try:
+        import win32api
+        import win32con
+        import win32event
+        import win32gui
+        import winerror
+    except Exception:  # pragma: no cover - pywin32 absent on non-Windows
+        return True
+
+    win32event.CreateMutex(None, False, "ZPLWebSingleton")
+    if win32api.GetLastError() == winerror.ERROR_ALREADY_EXISTS:
+        hwnd = win32gui.FindWindow(None, window_title)
+        if hwnd:
+            win32gui.ShowWindow(hwnd, win32con.SW_RESTORE)
+            win32gui.SetForegroundWindow(hwnd)
+        return False
+    return True

--- a/tests/test_single_instance.py
+++ b/tests/test_single_instance.py
@@ -1,0 +1,55 @@
+"""Tests for Windows single-instance behavior."""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from ZPLWeb.utils import ensure_single_instance
+
+
+def test_existing_instance_brought_to_front(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    fake_modules = {
+        "win32event": SimpleNamespace(CreateMutex=MagicMock()),
+        "win32api": SimpleNamespace(GetLastError=MagicMock(return_value=183)),
+        "win32con": SimpleNamespace(SW_RESTORE=9),
+        "win32gui": SimpleNamespace(
+            FindWindow=MagicMock(return_value=42),
+            ShowWindow=MagicMock(),
+            SetForegroundWindow=MagicMock(),
+        ),
+        "winerror": SimpleNamespace(ERROR_ALREADY_EXISTS=183),
+    }
+    monkeypatch.setitem(sys.modules, "win32event", fake_modules["win32event"])
+    monkeypatch.setitem(sys.modules, "win32api", fake_modules["win32api"])
+    monkeypatch.setitem(sys.modules, "win32con", fake_modules["win32con"])
+    monkeypatch.setitem(sys.modules, "win32gui", fake_modules["win32gui"])
+    monkeypatch.setitem(sys.modules, "winerror", fake_modules["winerror"])
+
+    assert ensure_single_instance("T") is False
+    fake_modules["win32gui"].FindWindow.assert_called_with(None, "T")
+    fake_modules["win32gui"].ShowWindow.assert_called_with(42, 9)
+    fake_modules["win32gui"].SetForegroundWindow.assert_called_with(42)
+
+
+def test_primary_instance(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    fake_modules = {
+        "win32event": SimpleNamespace(CreateMutex=MagicMock()),
+        "win32api": SimpleNamespace(GetLastError=MagicMock(return_value=0)),
+        "win32con": SimpleNamespace(SW_RESTORE=9),
+        "win32gui": SimpleNamespace(
+            FindWindow=MagicMock(return_value=42),
+            ShowWindow=MagicMock(),
+            SetForegroundWindow=MagicMock(),
+        ),
+        "winerror": SimpleNamespace(ERROR_ALREADY_EXISTS=183),
+    }
+    monkeypatch.setitem(sys.modules, "win32event", fake_modules["win32event"])
+    monkeypatch.setitem(sys.modules, "win32api", fake_modules["win32api"])
+    monkeypatch.setitem(sys.modules, "win32con", fake_modules["win32con"])
+    monkeypatch.setitem(sys.modules, "win32gui", fake_modules["win32gui"])
+    monkeypatch.setitem(sys.modules, "winerror", fake_modules["winerror"])
+
+    assert ensure_single_instance("T") is True
+    fake_modules["win32gui"].FindWindow.assert_not_called()


### PR DESCRIPTION
## Summary
- ensure only one Windows instance runs by using a named mutex and focusing existing window
- correct error constant used for detecting existing Windows instances
- add tests for Windows single-instance handling

## Testing
- `ruff check .`
- `PYTHONPATH=. pytest tests/test_single_instance.py tests/test_utils.py`
- `PYTHONPATH=. pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

## Label
fix

------
https://chatgpt.com/codex/tasks/task_e_68a43af0b0c483229e05e6aefb51cd6c