### PR TITLE
fix(utils): use winerror constant for mutex check

### DIFF
--- a/ZPLWeb/utils.py
+++ b/ZPLWeb/utils.py
@@ -51,11 +51,13 @@ def ensure_single_instance(window_title: str) -> bool:
         import win32con
         import win32event
         import win32gui
+        import winerror
     except Exception:  # pragma: no cover - pywin32 absent on non-Windows
         return True
 
     win32event.CreateMutex(None, False, "ZPLWebSingleton")
-    if win32api.GetLastError() == win32con.ERROR_ALREADY_EXISTS:
+    # winerror exposes error codes; ERROR_ALREADY_EXISTS signals an existing mutex
+    if win32api.GetLastError() == winerror.ERROR_ALREADY_EXISTS:
         hwnd = win32gui.FindWindow(None, window_title)
         if hwnd:
             win32gui.ShowWindow(hwnd, win32con.SW_RESTORE)

--- a/tests/test_single_instance.py
+++ b/tests/test_single_instance.py
@@ -12,17 +12,19 @@ def test_existing_instance_brought_to_front(monkeypatch):
     fake_modules = {
         "win32event": SimpleNamespace(CreateMutex=MagicMock()),
         "win32api": SimpleNamespace(GetLastError=MagicMock(return_value=1)),
-        "win32con": SimpleNamespace(ERROR_ALREADY_EXISTS=1, SW_RESTORE=9),
+        "win32con": SimpleNamespace(SW_RESTORE=9),
         "win32gui": SimpleNamespace(
             FindWindow=MagicMock(return_value=42),
             ShowWindow=MagicMock(),
             SetForegroundWindow=MagicMock(),
         ),
+        "winerror": SimpleNamespace(ERROR_ALREADY_EXISTS=1),
     }
     monkeypatch.setitem(sys.modules, "win32event", fake_modules["win32event"])
     monkeypatch.setitem(sys.modules, "win32api", fake_modules["win32api"])
     monkeypatch.setitem(sys.modules, "win32con", fake_modules["win32con"])
     monkeypatch.setitem(sys.modules, "win32gui", fake_modules["win32gui"])
+    monkeypatch.setitem(sys.modules, "winerror", fake_modules["winerror"])
 
     assert ensure_single_instance("T") is False
     fake_modules["win32gui"].FindWindow.assert_called_with(None, "T")
@@ -35,17 +37,19 @@ def test_primary_instance(monkeypatch):
     fake_modules = {
         "win32event": SimpleNamespace(CreateMutex=MagicMock()),
         "win32api": SimpleNamespace(GetLastError=MagicMock(return_value=0)),
-        "win32con": SimpleNamespace(ERROR_ALREADY_EXISTS=1, SW_RESTORE=9),
+        "win32con": SimpleNamespace(SW_RESTORE=9),
         "win32gui": SimpleNamespace(
             FindWindow=MagicMock(return_value=42),
             ShowWindow=MagicMock(),
             SetForegroundWindow=MagicMock(),
         ),
+        "winerror": SimpleNamespace(ERROR_ALREADY_EXISTS=1),
     }
     monkeypatch.setitem(sys.modules, "win32event", fake_modules["win32event"])
     monkeypatch.setitem(sys.modules, "win32api", fake_modules["win32api"])
     monkeypatch.setitem(sys.modules, "win32con", fake_modules["win32con"])
     monkeypatch.setitem(sys.modules, "win32gui", fake_modules["win32gui"])
+    monkeypatch.setitem(sys.modules, "winerror", fake_modules["winerror"])
 
     assert ensure_single_instance("T") is True
     fake_modules["win32gui"].FindWindow.assert_not_called()


### PR DESCRIPTION
## Summary
- replace missing win32con constant with winerror for single-instance check
- adjust tests to mock winerror module

## Testing
- `isort .`
- `black .`
- `ruff check . --fix`
- `QT_QPA_PLATFORM=offscreen PYTHONPATH=. pytest tests/test_single_instance.py tests/test_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a441e0e26c83229fb8e0207c0aa7cb