### PR TITLE
fix(app): enforce single instance and exit cleanly

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,24 @@
+"""Tests for the application entry point."""
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("PySide6.QtWidgets")
+import ZPLWeb.main as main_module
+
+
+def test_second_instance_warns_and_exits(monkeypatch):
+    """A warning is shown and the process exits when already running."""
+    monkeypatch.setattr(main_module, "ensure_single_instance", lambda *_: False)
+    monkeypatch.setattr(main_module, "QApplication", MagicMock())
+    warn_mock = MagicMock()
+    monkeypatch.setattr(main_module.QMessageBox, "warning", warn_mock)
+    exit_mock = MagicMock()
+    monkeypatch.setattr(sys, "exit", exit_mock)
+
+    main_module.main()
+
+    warn_mock.assert_called_once()
+    exit_mock.assert_called_once_with(0)


### PR DESCRIPTION
## Summary
- ensure only one instance runs and show warning when launching a second copy
- remove system tray behavior and disconnect sockets on exit
- test single-instance startup warning

## Testing
- `ruff check tests/test_main.py`
- `PYTHONPATH=$PWD pytest tests/test_utils.py tests/test_single_instance.py -q`
- `PYTHONPATH=$PWD pytest tests/test_main.py -q` *(fails: Module 'PySide6.QtWidgets' import error: libGL.so.1 missing)*


------
https://chatgpt.com/codex/tasks/task_e_68a5783cb0988322bed2ccb7f714ed04