### PR TITLE
fix(instance): stabilize lock path for frozen builds

### DIFF
--- a/tests/test_ack.py
+++ b/tests/test_ack.py
@@ -24,6 +24,9 @@ def test_emit_ack_updates_db(app, tmp_path, monkeypatch):
         def emit(self, event, data):
             self.last = (event, data)
 
+        def disconnect(self) -> None:  # pragma: no cover - called on close
+            self.connected = False
+
     win.sio = DummySio()
     win._emit_ack(job_id)
     assert win._is_job_acked(job_id)


### PR DESCRIPTION
## Summary
- ensure single-instance lock file resides in shared temp dir for PyInstaller builds
- add regression test for lock path selection
- fix GUI ack test dummy socket with disconnect

## Testing
- `QT_QPA_PLATFORM=offscreen PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a57b1be4308322bf1c7ba3ba0aeabb