### PR TITLE
fix(single-instance): enforce global single instance

### DIFF
--- a/ZPLWeb/utils.py
+++ b/ZPLWeb/utils.py
@@ -55,6 +55,7 @@ def _lock_file_path() -> Path:
 
 
 _LOCK_FILE = _lock_file_path()
+_SINGLETON_MUTEX = None
 
 
 def _pid_alive(pid: int) -> bool:
@@ -91,7 +92,10 @@ def ensure_single_instance(window_title: str) -> bool:
             import win32gui
             import winerror
 
-            win32event.CreateMutex(None, False, "ZPLWebSingleton")
+            global _SINGLETON_MUTEX
+            _SINGLETON_MUTEX = win32event.CreateMutex(
+                None, False, "Global\\ZPLWebSingleton"
+            )
             if win32api.GetLastError() == winerror.ERROR_ALREADY_EXISTS:
                 hwnd = win32gui.FindWindow(None, window_title)
                 if hwnd:

--- a/tests/test_single_instance.py
+++ b/tests/test_single_instance.py
@@ -29,6 +29,9 @@ def test_existing_instance_brought_to_front(monkeypatch):
     monkeypatch.setitem(sys.modules, "winerror", fake_modules["winerror"])
 
     assert utils.ensure_single_instance("T") is False
+    fake_modules["win32event"].CreateMutex.assert_called_with(
+        None, False, "Global\\ZPLWebSingleton"
+    )
     fake_modules["win32gui"].FindWindow.assert_called_with(None, "T")
     fake_modules["win32gui"].ShowWindow.assert_called_with(42, 9)
     fake_modules["win32gui"].SetForegroundWindow.assert_called_with(42)
@@ -54,7 +57,11 @@ def test_primary_instance(monkeypatch):
     monkeypatch.setitem(sys.modules, "winerror", fake_modules["winerror"])
 
     assert utils.ensure_single_instance("T") is True
+    fake_modules["win32event"].CreateMutex.assert_called_with(
+        None, False, "Global\\ZPLWebSingleton"
+    )
     fake_modules["win32gui"].FindWindow.assert_not_called()
+    assert utils._SINGLETON_MUTEX == fake_modules["win32event"].CreateMutex.return_value
 
 
 def test_file_lock_fallback(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- ensure Windows builds use a global mutex so only one instance runs at a time
- cover global mutex behavior with unit tests

## Testing
- `isort ZPLWeb/utils.py tests/test_single_instance.py`
- `black ZPLWeb/utils.py tests/test_single_instance.py`
- `ruff check ZPLWeb/utils.py tests/test_single_instance.py`
- `PYTHONPATH=. pytest tests/test_single_instance.py tests/test_utils.py -q`
- `PYTHONPATH=. pytest -q` *(fails: Fatal Python error: Aborted)*


------
https://chatgpt.com/codex/tasks/task_e_68a57d4d03c88322a9cedcac12281f2d